### PR TITLE
Fixed missing "page-item" class in bootstrap 4 template.

### DIFF
--- a/src/django_rangepaginator/templates/django_rangepaginator/bootstrap4.html
+++ b/src/django_rangepaginator/templates/django_rangepaginator/bootstrap4.html
@@ -29,7 +29,7 @@
                 <a class="page-link" href="#">{{ page_num }}<span class="sr-only">(current)</span></a>
             </li>
             {% elif page_num %}
-            <li>
+            <li class="page-item">
                 <a href="{{ url }}" class="page-link">{{ page_num }}</a>
             </li>
             {% else %}


### PR DESCRIPTION
Bootstrap 4 requires the "page-item" class in all `<li>` tags. Added.